### PR TITLE
Bump to latest Spring and Jackson-BOM versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.6.RELEASE</version>
+		<version>2.1.7.RELEASE</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.st.utopia</groupId>
@@ -17,7 +17,7 @@
 
 	<properties>
 		<java.version>1.8</java.version>
-		<jackson.version>2.9.9.20190727</jackson.version>
+		<jackson.version>2.9.9.20190807</jackson.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
I haven't even build-tested this, since I don't have a local checkout, but since 
the booking service built fine with the same change I don't expect problems
here either.