### PR TITLE
Add BetterCodeHub configuration file

### DIFF
--- a/.bettercodehub.yml
+++ b/.bettercodehub.yml
@@ -1,0 +1,1 @@
+component_depth: 8


### PR DESCRIPTION
Without this file containing this line, it thinks that the entire project is one big module named `src`. This is the same content as utopia-airlines/UtopiaBookingService#14, which was merged into that project back in July.